### PR TITLE
build mbedtls sources required for spake2plus

### DIFF
--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -63,12 +63,14 @@ target_sources(mbedcrypto PRIVATE
     repo/library/ecp_curves.c
     repo/library/entropy.c
     repo/library/entropy_poll.c
+    repo/library/hkdf.c
     repo/library/md.c
     repo/library/md_wrap.c
     repo/library/memory_buffer_alloc.c
     repo/library/oid.c
     repo/library/pem.c
     repo/library/pk.c
+    repo/library/pkcs5.c
     repo/library/pk_wrap.c
     repo/library/pkparse.c
     repo/library/platform.c

--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(mbedcrypto PRIVATE
     repo/library/ecjpake.c
     repo/library/ecp.c
     repo/library/ecp_curves.c
+    repo/library/error.c
     repo/library/entropy.c
     repo/library/entropy_poll.c
     repo/library/hkdf.c


### PR DESCRIPTION
The KNX-IoT port is using Openthread's MBEDTLS build, which does not include some of the source files needed for Spake2+. This pull request adds those sources. The impact on our other targets should be minimal, as the linker only pulls in functions that are actually used within a binary.