### PR TITLE
Patch related to processing incoming frames with key id mode 2

### DIFF
--- a/src/core/mac_extern/mac/mac_frame.hpp
+++ b/src/core/mac_extern/mac/mac_frame.hpp
@@ -403,10 +403,7 @@ public:
      * @returns A pointer to the Time IE, `nullptr` if not found.
      *
      */
-    TimeIe *GetTimeIe(void)
-    {
-        return AsNonConst(AsConst(this)->GetTimeIe());
-    }
+    TimeIe *GetTimeIe(void) { return AsNonConst(AsConst(this)->GetTimeIe()); }
 
     /**
      * This method returns a pointer to the vendor specific Time IE.
@@ -483,10 +480,7 @@ public:
      * @returns Frame's radio link type.
      *
      */
-    RadioType GetRadioType(void) const
-    {
-        return static_cast<RadioType>(mRadioType);
-    }
+    RadioType GetRadioType(void) const { return static_cast<RadioType>(mRadioType); }
 
     /**
      * This method sets the radio link type of the frame.
@@ -494,10 +488,7 @@ public:
      * @param[in] aRadioType  A radio link type.
      *
      */
-    void SetRadioType(RadioType aRadioType)
-    {
-        mRadioType = static_cast<uint8_t>(aRadioType);
-    }
+    void SetRadioType(RadioType aRadioType) { mRadioType = static_cast<uint8_t>(aRadioType); }
 #endif
 
 protected:
@@ -508,14 +499,8 @@ protected:
 
     static uint8_t GetKeySourceLength(uint8_t aKeyIdMode);
 
-    static bool IsDstAddrPresent(uint16_t aFcf)
-    {
-        return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone;
-    }
-    static bool IsVersion2015(uint16_t aFcf)
-    {
-        return (aFcf & kFcfFrameVersionMask) == kFcfFrameVersion2015;
-    }
+    static bool IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone; }
+    static bool IsVersion2015(uint16_t aFcf) { return (aFcf & kFcfFrameVersionMask) == kFcfFrameVersion2015; }
 
     static uint8_t CalculateSecurityHeaderSize(uint8_t aSecurityControl);
     static uint8_t CalculateMicSize(uint8_t aSecurityControl);
@@ -664,6 +649,20 @@ public:
     }
 
     /**
+     * This method gets the Key Identifier Mode.
+     *
+     * @param[out]  aKeyIdMode  The Key Identifier Mode.
+     *
+     * @retval kErrorNone  Successfully retrieved the Key Identifier Mode.
+     *
+     */
+    Error GetKeyIdMode(uint8_t &aKeyIdMode) const
+    {
+        aKeyIdMode = mSecurity.mKeyIdMode;
+        return kErrorNone;
+    }
+
+    /**
      * This method returns the current MAC Payload length.
      *
      * @returns The current MAC Payload length.
@@ -721,10 +720,7 @@ public:
      * @returns  The time sync sequence.
      *
      */
-    uint8_t ReadTimeSyncSeq(void) const
-    {
-        return GetTimeIe()->GetSequence();
-    }
+    uint8_t ReadTimeSyncSeq(void) const { return GetTimeIe()->GetSequence(); }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 };
 
@@ -1073,10 +1069,7 @@ public:
      * @param[in]  aOffset  The Time IE offset, 0 means no Time IE.
      *
      */
-    void SetTimeIeOffset(uint8_t aOffset)
-    {
-        mInfo.mTxInfo.mIeInfo->mTimeIeOffset = aOffset;
-    }
+    void SetTimeIeOffset(uint8_t aOffset) { mInfo.mTxInfo.mIeInfo->mTimeIeOffset = aOffset; }
 
     /**
      * This method sets the offset to network time.
@@ -1095,10 +1088,7 @@ public:
      * @param[in]  aTimeSyncSeq  The time sync sequence.
      *
      */
-    void SetTimeSyncSeq(uint8_t aTimeSyncSeq)
-    {
-        mInfo.mTxInfo.mIeInfo->mTimeSyncSeq = aTimeSyncSeq;
-    }
+    void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { mInfo.mTxInfo.mIeInfo->mTimeSyncSeq = aTimeSyncSeq; }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
     /**
@@ -1122,10 +1112,7 @@ public:
      * @param[in]    aTxDelay    The delay time for the TX frame.
      *
      */
-    void SetTxDelay(uint32_t aTxDelay)
-    {
-        mInfo.mTxInfo.mTxDelay = aTxDelay;
-    }
+    void SetTxDelay(uint32_t aTxDelay) { mInfo.mTxInfo.mTxDelay = aTxDelay; }
 
     /**
      * Set TX delay base time field for the frame.
@@ -1133,10 +1120,7 @@ public:
      * @param[in]    aTxDelayBaseTime    The delay base time for the TX frame.
      *
      */
-    void SetTxDelayBaseTime(uint32_t aTxDelayBaseTime)
-    {
-        mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime;
-    }
+    void SetTxDelayBaseTime(uint32_t aTxDelayBaseTime) { mInfo.mTxInfo.mTxDelayBaseTime = aTxDelayBaseTime; }
 #endif
 };
 
@@ -1254,10 +1238,7 @@ public:
      * @returns The Network Name field as `NameData`.
      *
      */
-    NameData GetNetworkName(void) const
-    {
-        return NameData(mNetworkName, sizeof(mNetworkName));
-    }
+    NameData GetNetworkName(void) const { return NameData(mNetworkName, sizeof(mNetworkName)); }
 
     /**
      * This method sets the Network Name field.
@@ -1265,10 +1246,7 @@ public:
      * @param[in]  aNameData  The Network Name (as a `NameData`).
      *
      */
-    void SetNetworkName(const NameData &aNameData)
-    {
-        aNameData.CopyTo(mNetworkName, sizeof(mNetworkName));
-    }
+    void SetNetworkName(const NameData &aNameData) { aNameData.CopyTo(mNetworkName, sizeof(mNetworkName)); }
 
     /**
      * This method returns the Extended PAN ID field.
@@ -1276,10 +1254,7 @@ public:
      * @returns The Extended PAN ID field.
      *
      */
-    const ExtendedPanId &GetExtendedPanId(void) const
-    {
-        return mExtendedPanId;
-    }
+    const ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
      * This method sets the Extended PAN ID field.
@@ -1287,10 +1262,7 @@ public:
      * @param[in]  aExtPanId  An Extended PAN ID.
      *
      */
-    void SetExtendedPanId(const ExtendedPanId &aExtPanId)
-    {
-        mExtendedPanId = aExtPanId;
-    }
+    void SetExtendedPanId(const ExtendedPanId &aExtPanId) { mExtendedPanId = aExtPanId; }
 
     /**
      * This method returns information about the Beacon as a `InfoString`.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -75,10 +75,21 @@ void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
         mIsDstPanIdBroadcast = (dstPanId == Mac::kPanIdBroadcast);
     }
 
-    mChannel      = aFrame.GetChannel();
-    mRss          = aFrame.GetRssi();
-    mLqi          = aFrame.GetLqi();
-    mLinkSecurity = aFrame.GetSecurityEnabled();
+    if (aFrame.GetSecurityEnabled())
+    {
+        uint8_t keyIdMode;
+
+        // MAC Frame Security was already validated at the MAC
+        // layer. As a result, `GetKeyIdMode()` will never return
+        // failure here.
+        IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
+
+        mLinkSecurity = (keyIdMode == Mac::Frame::kKeyIdMode0) || (keyIdMode == Mac::Frame::kKeyIdMode1);
+    }
+
+    mChannel = aFrame.GetChannel();
+    mRss     = aFrame.GetRssi();
+    mLqi     = aFrame.GetLqi();
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aFrame.GetTimeIe() != nullptr)
     {


### PR DESCRIPTION
Implements the following text in the Thread 1.1.1 spec, 7.2.1.3:

```
Thread nodes MUST enforce specific processing of such messages as if they are unsecured at the MAC layer."
```