### PR TITLE
[Mpl] Don't maintain a seed set if rx-off-when-idle

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -97,9 +97,12 @@ Error Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOut
     }
 
     // Check if the MPL Data Message is new.
+    // NOTE: Don't maintain the seed set if the device is a rx-off-when-idle child,
+    //       because that causes the sleepy device to wake up periodically in order
+    //       to update the LifeTimes in the Seed Set.
     if (otThreadGetLinkMode(GetInstancePtr()).mRxOnWhenIdle)
         error = UpdateSeedSet(option.GetSeedId(), option.GetSequence());
-    else // Don't maintain the seed set if the device is a rx-off-when-idle child
+    else
         error = kErrorNone;
 
     if (error == kErrorNone)

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -41,6 +41,8 @@
 #include "common/serial_number.hpp"
 #include "net/ip6.hpp"
 
+#include <openthread/thread.h>
+
 namespace ot {
 namespace Ip6 {
 
@@ -95,7 +97,10 @@ Error Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsOut
     }
 
     // Check if the MPL Data Message is new.
-    error = UpdateSeedSet(option.GetSeedId(), option.GetSequence());
+    if (otThreadGetLinkMode(GetInstancePtr()).mRxOnWhenIdle)
+        error = UpdateSeedSet(option.GetSeedId(), option.GetSequence());
+    else // Don't maintain the seed set if the device is a rx-off-when-idle child
+        error = kErrorNone;
 
     if (error == kErrorNone)
     {

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -322,6 +322,9 @@ private:
     TimerMilli   mRetransmissionTimer;
     uint8_t      mTimerExpirations;
 #endif // OPENTHREAD_FTD
+
+    otInstance *GetInstancePtr(void) { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
+
 };
 
 /**


### PR DESCRIPTION
A Rx-off-when-idle child was previously waking up every second for 5 seconds after sending/receiving Realm-local multicast messages (such as s-mode messages), in order to maintain the MPL Seed Set. 

This change suppresses that behaviour, meaning the MPL Seed Set for a rx-off-when-idle is now no longer going to be maintained. From reading the specs, thinking about it, looking at the code, and testing, I believe that this won't have any negative effect on the network. I think that the important thing is that the child's PARENT (which is never going to be a rx-off-when-idle device) maintains its own Seed Set, which will ensure that no duplicates/non-ordered MPL Data Messages are going to get forwarded to the child itself.