### PR TITLE
Adds API for resynchronizing sleepy child with its parent

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (200)
+#define OPENTHREAD_API_VERSION (201)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -245,13 +245,13 @@ bool otThreadIsSingleton(otInstance *aInstance);
  * @retval OT_ERROR_BUSY           Thread Discovery Scan is already in progress.
  *
  */
-otError otThreadDiscover(otInstance              *aInstance,
+otError otThreadDiscover(otInstance *             aInstance,
                          uint32_t                 aScanChannels,
                          uint16_t                 aPanId,
                          bool                     aJoiner,
                          bool                     aEnableEui64Filtering,
                          otHandleActiveScanResult aCallback,
-                         void                    *aCallbackContext);
+                         void *                   aCallbackContext);
 
 /**
  * This function determines if an MLE Thread Discovery is currently in progress.
@@ -278,7 +278,7 @@ bool otThreadIsDiscoverInProgress(otInstance *aInstance);
  * @retval OT_ERROR_INVALID_ARGS Invalid AdvData.
  *
  */
-otError otThreadSetJoinerAdvertisement(otInstance    *aInstance,
+otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
                                        uint32_t       aOui,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength);
@@ -902,9 +902,9 @@ typedef void (*otThreadParentResponseCallback)(otThreadParentResponseInfo *aInfo
  * @param[in]  aContext   A pointer to callback client-specific context.
  *
  */
-void otThreadRegisterParentResponseCallback(otInstance                    *aInstance,
+void otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
                                             otThreadParentResponseCallback aCallback,
-                                            void                          *aContext);
+                                            void *                         aContext);
 
 /**
  * This structure represents the Thread Discovery Request data.
@@ -934,9 +934,9 @@ typedef void (*otThreadDiscoveryRequestCallback)(const otThreadDiscoveryRequestI
  * @param[in]  aContext   A pointer to callback application-specific context.
  *
  */
-void otThreadSetDiscoveryRequestCallback(otInstance                      *aInstance,
+void otThreadSetDiscoveryRequestCallback(otInstance *                     aInstance,
                                          otThreadDiscoveryRequestCallback aCallback,
-                                         void                            *aContext);
+                                         void *                           aContext);
 
 /**
  * This function pointer type defines the callback to notify the outcome of a `otThreadLocateAnycastDestination()`
@@ -951,7 +951,7 @@ void otThreadSetDiscoveryRequestCallback(otInstance                      *aInsta
  * @param[in] aRloc16             The RLOC16 of the destination if found, otherwise invalid RLOC16 (0xfffe).
  *
  */
-typedef void (*otThreadAnycastLocatorCallback)(void               *aContext,
+typedef void (*otThreadAnycastLocatorCallback)(void *              aContext,
                                                otError             aError,
                                                const otIp6Address *aMeshLocalAddress,
                                                uint16_t            aRloc16);
@@ -973,10 +973,10 @@ typedef void (*otThreadAnycastLocatorCallback)(void               *aContext,
  * @retval OT_ERROR_NO_BUFS       Out of buffer to prepare and send the request message.
  *
  */
-otError otThreadLocateAnycastDestination(otInstance                    *aInstance,
-                                         const otIp6Address            *aAnycastAddress,
+otError otThreadLocateAnycastDestination(otInstance *                   aInstance,
+                                         const otIp6Address *           aAnycastAddress,
                                          otThreadAnycastLocatorCallback aCallback,
-                                         void                          *aContext);
+                                         void *                         aContext);
 
 /**
  * This function indicates whether an anycast locate request is currently in progress.
@@ -1001,9 +1001,9 @@ bool otThreadIsAnycastLocateInProgress(otInstance *aInstance);
  * @param[in]  aMlIid        The ML-IID of the ADDR_NTF.ntf message.
  *
  */
-void otThreadSendAddressNotification(otInstance               *aInstance,
-                                     otIp6Address             *aDestination,
-                                     otIp6Address             *aTarget,
+void otThreadSendAddressNotification(otInstance *              aInstance,
+                                     otIp6Address *            aDestination,
+                                     otIp6Address *            aTarget,
                                      otIp6InterfaceIdentifier *aMlIid);
 
 /**
@@ -1020,8 +1020,8 @@ void otThreadSendAddressNotification(otInstance               *aInstance,
  * @retval OT_ERROR_NO_BUFS        If insufficient message buffers available.
  *
  */
-otError otThreadSendProactiveBackboneNotification(otInstance               *aInstance,
-                                                  otIp6Address             *aTarget,
+otError otThreadSendProactiveBackboneNotification(otInstance *              aInstance,
+                                                  otIp6Address *            aTarget,
                                                   otIp6InterfaceIdentifier *aMlIid,
                                                   uint32_t                  aTimeSinceLastTransaction);
 

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -245,13 +245,13 @@ bool otThreadIsSingleton(otInstance *aInstance);
  * @retval OT_ERROR_BUSY           Thread Discovery Scan is already in progress.
  *
  */
-otError otThreadDiscover(otInstance *             aInstance,
+otError otThreadDiscover(otInstance              *aInstance,
                          uint32_t                 aScanChannels,
                          uint16_t                 aPanId,
                          bool                     aJoiner,
                          bool                     aEnableEui64Filtering,
                          otHandleActiveScanResult aCallback,
-                         void *                   aCallbackContext);
+                         void                    *aCallbackContext);
 
 /**
  * This function determines if an MLE Thread Discovery is currently in progress.
@@ -278,12 +278,28 @@ bool otThreadIsDiscoverInProgress(otInstance *aInstance);
  * @retval OT_ERROR_INVALID_ARGS Invalid AdvData.
  *
  */
-otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
+otError otThreadSetJoinerAdvertisement(otInstance    *aInstance,
                                        uint32_t       aOui,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength);
 
 #define OT_JOINER_ADVDATA_MAX_LENGTH 64 ///< Maximum AdvData Length of Joiner Advertisement
+
+/**
+ * Resynchronize a sleepy child with its parent, in case the Keep-alives
+ * are getting erroneously acknowledged. This function will send a child
+ * update request to the parent, if the device is a rx-off-when-idle (i.e. sleepy)
+ * child.
+ *
+ * @param aInstance A pointer to an OpenThread instance.
+ *
+ * @retval OT_ERROR_NONE           Successfully attempted to resynchronize with the parent.
+ * @retval OT_ERROR_REJECTED       The device is not a rx-off-when-idle child, so
+ *                                 no attempt to resynchronize was made
+ * @retval OT_ERROR_NO_BUFS        Insufficient buffers to generate the MLE Child Update Request.
+ *
+ */
+otError otThreadSleepyChildResynchronize(otInstance *aInstance);
 
 /**
  * Get the Thread Child Timeout used when operating in the Child role.
@@ -886,9 +902,9 @@ typedef void (*otThreadParentResponseCallback)(otThreadParentResponseInfo *aInfo
  * @param[in]  aContext   A pointer to callback client-specific context.
  *
  */
-void otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
+void otThreadRegisterParentResponseCallback(otInstance                    *aInstance,
                                             otThreadParentResponseCallback aCallback,
-                                            void *                         aContext);
+                                            void                          *aContext);
 
 /**
  * This structure represents the Thread Discovery Request data.
@@ -918,9 +934,9 @@ typedef void (*otThreadDiscoveryRequestCallback)(const otThreadDiscoveryRequestI
  * @param[in]  aContext   A pointer to callback application-specific context.
  *
  */
-void otThreadSetDiscoveryRequestCallback(otInstance *                     aInstance,
+void otThreadSetDiscoveryRequestCallback(otInstance                      *aInstance,
                                          otThreadDiscoveryRequestCallback aCallback,
-                                         void *                           aContext);
+                                         void                            *aContext);
 
 /**
  * This function pointer type defines the callback to notify the outcome of a `otThreadLocateAnycastDestination()`
@@ -935,7 +951,7 @@ void otThreadSetDiscoveryRequestCallback(otInstance *                     aInsta
  * @param[in] aRloc16             The RLOC16 of the destination if found, otherwise invalid RLOC16 (0xfffe).
  *
  */
-typedef void (*otThreadAnycastLocatorCallback)(void *              aContext,
+typedef void (*otThreadAnycastLocatorCallback)(void               *aContext,
                                                otError             aError,
                                                const otIp6Address *aMeshLocalAddress,
                                                uint16_t            aRloc16);
@@ -957,10 +973,10 @@ typedef void (*otThreadAnycastLocatorCallback)(void *              aContext,
  * @retval OT_ERROR_NO_BUFS       Out of buffer to prepare and send the request message.
  *
  */
-otError otThreadLocateAnycastDestination(otInstance *                   aInstance,
-                                         const otIp6Address *           aAnycastAddress,
+otError otThreadLocateAnycastDestination(otInstance                    *aInstance,
+                                         const otIp6Address            *aAnycastAddress,
                                          otThreadAnycastLocatorCallback aCallback,
-                                         void *                         aContext);
+                                         void                          *aContext);
 
 /**
  * This function indicates whether an anycast locate request is currently in progress.
@@ -985,9 +1001,9 @@ bool otThreadIsAnycastLocateInProgress(otInstance *aInstance);
  * @param[in]  aMlIid        The ML-IID of the ADDR_NTF.ntf message.
  *
  */
-void otThreadSendAddressNotification(otInstance *              aInstance,
-                                     otIp6Address *            aDestination,
-                                     otIp6Address *            aTarget,
+void otThreadSendAddressNotification(otInstance               *aInstance,
+                                     otIp6Address             *aDestination,
+                                     otIp6Address             *aTarget,
                                      otIp6InterfaceIdentifier *aMlIid);
 
 /**
@@ -1004,8 +1020,8 @@ void otThreadSendAddressNotification(otInstance *              aInstance,
  * @retval OT_ERROR_NO_BUFS        If insufficient message buffers available.
  *
  */
-otError otThreadSendProactiveBackboneNotification(otInstance *              aInstance,
-                                                  otIp6Address *            aTarget,
+otError otThreadSendProactiveBackboneNotification(otInstance               *aInstance,
+                                                  otIp6Address             *aTarget,
                                                   otIp6InterfaceIdentifier *aMlIid,
                                                   uint32_t                  aTimeSinceLastTransaction);
 

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -43,7 +43,7 @@
 
 using namespace ot;
 
-otError otThreadSleepyChildResynchronize(otInstance *aInstance)
+uint32_t otError otThreadSleepyChildResynchronize(otInstance *aInstance)
 {
     Error     error    = kErrorNone;
     Instance &instance = AsCoreType(aInstance);
@@ -57,7 +57,7 @@ exit:
     return error;
 }
 
-uint32_t otThreadGetChildTimeout(otInstance *aInstance)
+otThreadGetChildTimeout(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetTimeout();
 }
@@ -75,7 +75,7 @@ const otExtendedPanId *otThreadGetExtendedPanId(otInstance *aInstance)
 otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *aExtendedPanId)
 {
     Error                     error    = kErrorNone;
-    Instance                 &instance = AsCoreType(aInstance);
+    Instance &                instance = AsCoreType(aInstance);
     const Mac::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
     Mle::MeshLocalPrefix      prefix;
 
@@ -268,7 +268,7 @@ otError otThreadSetFixedDuaInterfaceIdentifier(otInstance *aInstance, const otIp
 
 const otIp6InterfaceIdentifier *otThreadGetFixedDuaInterfaceIdentifier(otInstance *aInstance)
 {
-    Instance                       &instance = AsCoreType(aInstance);
+    Instance &                      instance = AsCoreType(aInstance);
     const otIp6InterfaceIdentifier *iid      = nullptr;
 
     if (instance.Get<DuaManager>().IsFixedDuaInterfaceIdentifierSet())
@@ -447,20 +447,20 @@ bool otThreadIsSingleton(otInstance *aInstance)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton();
 }
 
-otError otThreadDiscover(otInstance              *aInstance,
+otError otThreadDiscover(otInstance *             aInstance,
                          uint32_t                 aScanChannels,
                          uint16_t                 aPanId,
                          bool                     aJoiner,
                          bool                     aEnableEui64Filtering,
                          otHandleActiveScanResult aCallback,
-                         void                    *aCallbackContext)
+                         void *                   aCallbackContext)
 {
     return AsCoreType(aInstance).Get<Mle::DiscoverScanner>().Discover(
         Mac::ChannelMask(aScanChannels), aPanId, aJoiner, aEnableEui64Filtering,
         /* aFilterIndexes (use hash of factory EUI64) */ nullptr, aCallback, aCallbackContext);
 }
 
-otError otThreadSetJoinerAdvertisement(otInstance    *aInstance,
+otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
                                        uint32_t       aOui,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength)
@@ -493,18 +493,18 @@ void otThreadResetMleCounters(otInstance *aInstance)
     AsCoreType(aInstance).Get<Mle::MleRouter>().ResetCounters();
 }
 
-void otThreadRegisterParentResponseCallback(otInstance                    *aInstance,
+void otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
                                             otThreadParentResponseCallback aCallback,
-                                            void                          *aContext)
+                                            void *                         aContext)
 {
     AsCoreType(aInstance).Get<Mle::MleRouter>().RegisterParentResponseStatsCallback(aCallback, aContext);
 }
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
-otError otThreadLocateAnycastDestination(otInstance                    *aInstance,
-                                         const otIp6Address            *aAnycastAddress,
+otError otThreadLocateAnycastDestination(otInstance *                   aInstance,
+                                         const otIp6Address *           aAnycastAddress,
                                          otThreadAnycastLocatorCallback aCallback,
-                                         void                          *aContext)
+                                         void *                         aContext)
 {
     return AsCoreType(aInstance).Get<AnycastLocator>().Locate(AsCoreType(aAnycastAddress), aCallback, aContext);
 }

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -43,6 +43,20 @@
 
 using namespace ot;
 
+otError otThreadSleepyChildResynchronize(otInstance *aInstance)
+{
+    Error     error    = kErrorNone;
+    Instance &instance = AsCoreType(aInstance);
+
+    VerifyOrExit(instance.Get<Mle::MleRouter>().IsChild(), error = kErrorRejected);
+    VerifyOrExit(instance.Get<MeshForwarder>().GetRxOnWhenIdle() == false, error = kErrorRejected);
+
+    error = AsCoreType(aInstance).Get<Mle::MleRouter>().SendChildUpdateRequest();
+
+exit:
+    return error;
+}
+
 uint32_t otThreadGetChildTimeout(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Mle::MleRouter>().GetTimeout();
@@ -61,7 +75,7 @@ const otExtendedPanId *otThreadGetExtendedPanId(otInstance *aInstance)
 otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *aExtendedPanId)
 {
     Error                     error    = kErrorNone;
-    Instance &                instance = AsCoreType(aInstance);
+    Instance                 &instance = AsCoreType(aInstance);
     const Mac::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
     Mle::MeshLocalPrefix      prefix;
 
@@ -254,7 +268,7 @@ otError otThreadSetFixedDuaInterfaceIdentifier(otInstance *aInstance, const otIp
 
 const otIp6InterfaceIdentifier *otThreadGetFixedDuaInterfaceIdentifier(otInstance *aInstance)
 {
-    Instance &                      instance = AsCoreType(aInstance);
+    Instance                       &instance = AsCoreType(aInstance);
     const otIp6InterfaceIdentifier *iid      = nullptr;
 
     if (instance.Get<DuaManager>().IsFixedDuaInterfaceIdentifierSet())
@@ -433,20 +447,20 @@ bool otThreadIsSingleton(otInstance *aInstance)
     return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton();
 }
 
-otError otThreadDiscover(otInstance *             aInstance,
+otError otThreadDiscover(otInstance              *aInstance,
                          uint32_t                 aScanChannels,
                          uint16_t                 aPanId,
                          bool                     aJoiner,
                          bool                     aEnableEui64Filtering,
                          otHandleActiveScanResult aCallback,
-                         void *                   aCallbackContext)
+                         void                    *aCallbackContext)
 {
     return AsCoreType(aInstance).Get<Mle::DiscoverScanner>().Discover(
         Mac::ChannelMask(aScanChannels), aPanId, aJoiner, aEnableEui64Filtering,
         /* aFilterIndexes (use hash of factory EUI64) */ nullptr, aCallback, aCallbackContext);
 }
 
-otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
+otError otThreadSetJoinerAdvertisement(otInstance    *aInstance,
                                        uint32_t       aOui,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength)
@@ -479,18 +493,18 @@ void otThreadResetMleCounters(otInstance *aInstance)
     AsCoreType(aInstance).Get<Mle::MleRouter>().ResetCounters();
 }
 
-void otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
+void otThreadRegisterParentResponseCallback(otInstance                    *aInstance,
                                             otThreadParentResponseCallback aCallback,
-                                            void *                         aContext)
+                                            void                          *aContext)
 {
     AsCoreType(aInstance).Get<Mle::MleRouter>().RegisterParentResponseStatsCallback(aCallback, aContext);
 }
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
-otError otThreadLocateAnycastDestination(otInstance *                   aInstance,
-                                         const otIp6Address *           aAnycastAddress,
+otError otThreadLocateAnycastDestination(otInstance                    *aInstance,
+                                         const otIp6Address            *aAnycastAddress,
                                          otThreadAnycastLocatorCallback aCallback,
-                                         void *                         aContext)
+                                         void                          *aContext)
 {
     return AsCoreType(aInstance).Get<AnycastLocator>().Locate(AsCoreType(aAnycastAddress), aCallback, aContext);
 }


### PR DESCRIPTION
PLEASE NOTE: This PR is related to the following two other PRs, and in order for CI to pass on all the PRs, they should be merged in this order:
1. This PR here
2. Cascoda/knx_iot_code_gen#608
3. Cascoda/knx_iot_cascoda#138

New function `otThreadSleepyChildResynchronize()`, which will essentially send an MLE Child Update Request. Use this for child/parent resynchronization purposes, as described in the Thread spec Thread1.1.1 section 4.7.5, Timing Out Children:

>  Rx-off-when-idle Children SHOULD also periodically (at time intervals indicated by the application) resynchronize by
sending a Child Update Request to their Parent to avoid cases when the MAC Data Request
is being acknowledged erroneously by a receiver that is not a valid Parent.