### PR TITLE
fix assertion failure for indirect frames

### DIFF
--- a/src/core/mac_extern/data_poll_handler.cpp
+++ b/src/core/mac_extern/data_poll_handler.cpp
@@ -316,8 +316,9 @@ Mac::TxFrame *DataPollHandler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
         }
 
         error = mCallbacks.RegenerateFrame(*frame, fc.mContext, fc.GetChild(), fc.mUseExtAddr);
-        if (error)
-            goto exit;
+        // skip cache entry if not valid
+        if (error != OT_ERROR_NONE)
+            continue;
 
         frame->mMsduHandle = fc.GetMsduHandle();
         fc.mFramePending   = frame->GetFramePending();

--- a/src/core/mac_extern/data_poll_handler.cpp
+++ b/src/core/mac_extern/data_poll_handler.cpp
@@ -315,11 +315,13 @@ Mac::TxFrame *DataPollHandler::HandleFrameRequest(Mac::TxFrames &aTxFrames)
                 continue;
         }
 
-        error              = mCallbacks.RegenerateFrame(*frame, fc.mContext, fc.GetChild(), fc.mUseExtAddr);
+        error = mCallbacks.RegenerateFrame(*frame, fc.mContext, fc.GetChild(), fc.mUseExtAddr);
+        if (error)
+            goto exit;
+
         frame->mMsduHandle = fc.GetMsduHandle();
         fc.mFramePending   = frame->GetFramePending();
         pendingChild       = fc.mFramePending ? &fc.GetChild() : nullptr;
-        OT_ASSERT(error == kErrorNone);
         fc.mPendingRetransmit = false;
         Get<Mac::Mac>().RequestIndirectFrameTransmission();
         ExitNow();


### PR DESCRIPTION
This assertion failed on the mesh extender and brought down my test harness. Judging by the rest of the code in that function, it should be possible to skip a cache entry in case of an error instead of halting, so this is what this patch implements.