### PR TITLE
Add and expose Carrier Sense for a received frame and any given link with neighbors

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -44,7 +44,7 @@ jobs:
        fuzz-seconds: 1800
        dry-run: false
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
      if: failure()
      with:
        name: artifacts

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (201)
+#define OPENTHREAD_API_VERSION (202)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -63,6 +63,7 @@ typedef struct otThreadLinkInfo
     uint16_t mPanId;                   ///< Source PAN ID
     uint8_t  mChannel;                 ///< 802.15.4 Channel
     int8_t   mRss;                     ///< Received Signal Strength in dBm.
+    uint8_t  mCs;                      ///< Received Carrier Sense
     uint8_t  mLqi;                     ///< Link Quality Indicator for a received message.
     bool     mLinkSecurity : 1;        ///< Indicates whether or not link security is enabled.
     bool     mIsDstPanIdBroadcast : 1; ///< Indicates whether or not destination PAN ID is broadcast.

--- a/include/openthread/platform/radio-mac.h
+++ b/include/openthread/platform/radio-mac.h
@@ -288,7 +288,9 @@ typedef struct otDataRequest
 
 /**
  * This structure represents the MCPS-Data.Indication as defined in IEEE 802.15.4-2006.
- *
+ * NOTE: There is one member of this structure, namely mLinkCarrierSense, which is not 
+ *       part of an MCPS-Data.Indication. It is included here as a convenient and immediate
+ *       way to provide information about the Carrier Sense of the received data indication.
  */
 typedef struct otDataIndication
 {
@@ -296,6 +298,7 @@ typedef struct otDataIndication
     struct otFullAddr mDst;                          ///< Dst Address information of received frame
     uint8_t           mMsduLength;                   ///< Length of the received MSDU
     int8_t            mMpduLinkQuality;              ///< LQI of received frame - MUST be RSSI for openthread
+    uint8_t           mLinkCarrierSense;             ///< Carrier Sense (CS) of the received frame (NOT PART OF MCPS-Data.Indication)
     uint8_t           mDSN;                          ///< DSN of received frame
     uint8_t           mIsFramePending;               ///< Value of 'frame pending' in received frame
     uint8_t           mTimeStamp[4];                 ///< Timestamp of received frame (optional)

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -79,6 +79,7 @@ enum
     OT_RADIO_SYMBOL_TIME   = ((OT_RADIO_BITS_PER_OCTET / OT_RADIO_SYMBOLS_PER_OCTET) * 1000000) / OT_RADIO_BIT_RATE,
     OT_RADIO_LQI_NONE      = 0,   ///< LQI measurement not supported
     OT_RADIO_RSSI_INVALID  = 127, ///< Invalid or unknown RSSI value
+    OT_RADIO_CS_INVALID    = 0,   ///< Invalid or unknown CS value
     OT_RADIO_POWER_INVALID = 127, ///< Invalid or unknown power value
 };
 

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -97,6 +97,7 @@ typedef struct
     uint8_t      mLinkQualityIn;        ///< Link Quality In
     int8_t       mAverageRssi;          ///< Average RSSI
     int8_t       mLastRssi;             ///< Last observed RSSI
+    uint8_t      mLastCs;               ///< Last observed CS 
     uint16_t     mFrameErrorRate;       ///< Frame error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mMessageErrorRate;     ///< (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
     bool         mRxOnWhenIdle : 1;     ///< rx-on-when-idle
@@ -848,6 +849,19 @@ otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
  *
  */
 otError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi);
+
+/**
+ * The function retrieves the Carrier Sense of the last packet from the Thread Parent.
+ *
+ * @param[in]   aInstance    A pointer to an OpenThread instance.
+ * @param[out]  aLastCs A pointer to where the last CS should be placed.
+ *
+ * @retval OT_ERROR_NONE          Successfully retrieved the CS data.
+ * @retval OT_ERROR_FAILED        Unable to get CS data.
+ * @retval OT_ERROR_INVALID_ARGS  @p aLastCs is NULL.
+ *
+ */
+otError otThreadGetParentLastCs(otInstance *aInstance, uint8_t *aLastCs);
 
 /**
  * Get the IPv6 counters.

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -65,6 +65,7 @@ typedef struct
     uint8_t      mLinkQualityIn;        ///< Link Quality In
     int8_t       mAverageRssi;          ///< Average RSSI
     int8_t       mLastRssi;             ///< Last observed RSSI
+    uint8_t      mLastCs;               ///< Last observed CS 
     uint16_t     mFrameErrorRate;       ///< Frame error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mMessageErrorRate;     ///< (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
     uint16_t     mQueuedMessageCnt;     ///< Number of queued messages for the child.

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -421,6 +421,20 @@ exit:
     return error;
 }
 
+otError otThreadGetParentLastCs(otInstance *aInstance, uint8_t *aLastCs)
+{
+    Error error = kErrorNone;
+
+    OT_ASSERT(aLastCs != nullptr);
+
+    *aLastCs = AsCoreType(aInstance).Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetLastCs();
+
+    VerifyOrExit(*aLastCs != OT_RADIO_CS_INVALID, error = kErrorFailed);
+
+exit:
+    return error;
+}
+
 otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 {
     Error error = kErrorNone;

--- a/src/core/mac_extern/mac.cpp
+++ b/src/core/mac_extern/mac.cpp
@@ -1755,6 +1755,7 @@ void Mac::ProcessDataIndication(otDataIndication *aDataIndication)
 #endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
         neighbor->GetLinkInfo().AddRss(GetNoiseFloor(), dataInd.GetRssi());
+        neighbor->GetLinkInfo().SetCs(dataInd.GetCs());
 
         if (dataInd.GetSecurityEnabled())
         {

--- a/src/core/mac_extern/mac/mac_frame.hpp
+++ b/src/core/mac_extern/mac/mac_frame.hpp
@@ -540,6 +540,14 @@ public:
     int8_t GetRssi(void) const { return mMpduLinkQuality; }
 
     /**
+     * This method returns the CS (Carrier Sense) used for reception.
+     *
+     * @returns The CS used for reception.
+     *
+     */
+    uint8_t GetCs(void) const { return mLinkCarrierSense; }
+
+    /**
      * This method sets the RSSI in dBm used for reception.
      *
      * @param[in]  aRssi  The RSSI in dBm used for reception.

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -133,6 +133,7 @@ void LinkQualityInfo::Clear(void)
     mRssAverager.Clear();
     SetLinkQuality(0);
     mLastRss = OT_RADIO_RSSI_INVALID;
+    mLastCs = OT_RADIO_CS_INVALID;
 
     mFrameErrorRate.Clear();
     mMessageErrorRate.Clear();
@@ -181,6 +182,18 @@ exit:
     return;
 }
 #endif
+
+void LinkQualityInfo::SetCs(uint8_t aCs)
+{
+    uint8_t oldLinkQuality = kNoLinkQuality;
+
+    VerifyOrExit(aCs != OT_RADIO_CS_INVALID);
+
+    mLastCs = aCs;
+
+exit:
+    return;
+}
 
 #if OPENTHREAD_CONFIG_USE_EXTERNAL_MAC
 uint8_t LinkQualityInfo::GetLinkMargin(int8_t aNoiseFloor) const

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -185,8 +185,6 @@ exit:
 
 void LinkQualityInfo::SetCs(uint8_t aCs)
 {
-    uint8_t oldLinkQuality = kNoLinkQuality;
-
     VerifyOrExit(aCs != OT_RADIO_CS_INVALID);
 
     mLastCs = aCs;

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -281,7 +281,7 @@ public:
      * @param[in] aCs         A new received carrier sense value
      *
      */
-    void LinkQualityInfo::SetCs(uint8_t aCs);
+    void SetCs(uint8_t aCs);
 
     /**
      * This method returns the current average received signal strength value.

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -276,6 +276,14 @@ public:
 #endif
 
     /**
+     * This method sets the Carrier Sense (CS) object mLastCs
+     *
+     * @param[in] aCs         A new received carrier sense value
+     *
+     */
+    void LinkQualityInfo::SetCs(uint8_t aCs);
+
+    /**
      * This method returns the current average received signal strength value.
      *
      * @returns The current average value or @c OT_RADIO_RSSI_INVALID if no average is available.
@@ -346,6 +354,14 @@ public:
      *
      */
     int8_t GetLastRss(void) const { return mLastRss; }
+
+    /**
+     * Returns the most recent CS (Carrier Sense) value.
+     *
+     * @returns The most recent CS 
+     *
+     */
+    uint8_t GetLastCs(void) const { return mLastCs; }
 
     /**
      * This method adds a MAC frame transmission status (success/failure) and updates the frame tx error rate.
@@ -464,6 +480,7 @@ private:
     RssAverager mRssAverager;
     uint8_t     mLinkQuality;
     int8_t      mLastRss;
+    uint8_t     mLastCs;
 
     SuccessRateTracker mFrameErrorRate;
     SuccessRateTracker mMessageErrorRate;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -89,6 +89,7 @@ void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
 
     mChannel = aFrame.GetChannel();
     mRss     = aFrame.GetRssi();
+    mCs      = aFrame.GetCs();
     mLqi     = aFrame.GetLqi();
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aFrame.GetTimeIe() != nullptr)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -668,6 +668,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
                 neighbor->SetExtAddress(extAddr);
                 neighbor->GetLinkInfo().Clear();
                 neighbor->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+                neighbor->GetLinkInfo().SetCs(linkInfo->mCs);
                 neighbor->ResetLinkFailures();
                 neighbor->SetLastHeard(TimerMilli::GetNow());
                 neighbor->SetState(Neighbor::kStateLinkRequest);
@@ -1011,6 +1012,7 @@ Error MleRouter::HandleLinkAccept(const Message          &aMessage,
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();
     router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    router->GetLinkInfo().SetCs(linkInfo->mCs);
     router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin));
     router->ResetLinkFailures();
     router->SetState(Neighbor::kStateValid);
@@ -1389,6 +1391,7 @@ Error MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Message
                 router->SetExtAddress(extAddr);
                 router->GetLinkInfo().Clear();
                 router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+                router->GetLinkInfo().SetCs(linkInfo->mCs);
                 router->ResetLinkFailures();
                 router->SetLastHeard(TimerMilli::GetNow());
                 router->SetState(Neighbor::kStateLinkRequest);
@@ -1436,6 +1439,7 @@ Error MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Message
             router->SetExtAddress(extAddr);
             router->GetLinkInfo().Clear();
             router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+            router->GetLinkInfo().SetCs(linkInfo->mCs);
             router->ResetLinkFailures();
             router->SetLastHeard(TimerMilli::GetNow());
             router->SetState(Neighbor::kStateLinkRequest);
@@ -1714,6 +1718,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
         child->SetExtAddress(extAddr);
         child->GetLinkInfo().Clear();
         child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+        child->GetLinkInfo().SetCs(linkInfo->mCs);
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -2386,6 +2391,7 @@ void MleRouter::HandleChildIdRequest(const Message          &aMessage,
     child->SetDeviceMode(mode);
     child->SetVersion(static_cast<uint8_t>(version));
     child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    child->GetLinkInfo().SetCs(linkInfo->mCs);
     child->SetTimeout(timeout);
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     child->ClearLastRxFragmentTag();
@@ -2785,6 +2791,7 @@ void MleRouter::HandleChildUpdateResponse(const Message          &aMessage,
     child->SetLastHeard(TimerMilli::GetNow());
     child->SetKeySequence(aKeySequence);
     child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    child->GetLinkInfo().SetCs(linkInfo->mCs);
 
 exit:
     LogProcessError(kTypeChildUpdateResponseOfChild, error);

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -75,6 +75,7 @@ void Neighbor::Info::SetFrom(const Neighbor &aNeighbor)
     mLinkQualityIn    = aNeighbor.GetLinkInfo().GetLinkQuality();
     mAverageRssi      = aNeighbor.GetLinkInfo().GetAverageRss();
     mLastRssi         = aNeighbor.GetLinkInfo().GetLastRss();
+    mLastCs           = aNeighbor.GetLinkInfo().GetLastCs();
     mFrameErrorRate   = aNeighbor.GetLinkInfo().GetFrameErrorRate();
     mMessageErrorRate = aNeighbor.GetLinkInfo().GetMessageErrorRate();
     mRxOnWhenIdle     = aNeighbor.IsRxOnWhenIdle();
@@ -249,6 +250,7 @@ void Child::Info::SetFrom(const Child &aChild)
     mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality();
     mAverageRssi        = aChild.GetLinkInfo().GetAverageRss();
     mLastRssi           = aChild.GetLinkInfo().GetLastRss();
+    mLastCs             = aChild.GetLinkInfo().GetLastCs();
     mFrameErrorRate     = aChild.GetLinkInfo().GetFrameErrorRate();
     mMessageErrorRate   = aChild.GetLinkInfo().GetMessageErrorRate();
     mQueuedMessageCnt   = aChild.GetIndirectMessageCount();


### PR DESCRIPTION
The Carrier Sense for the last received frame can now be retrieved, in a similar way as how the RSSI can be retrieved. There are two ways to do this, based on the device role.

- If the device is a child, it can retrieve the CS of the last packet received by its parent via the function `otThreadGetParentLastCs()`
- If the device is a router/leader, it can retrieve the CS of the last packet received by any of its neighbors, by iterating through the list of neighbors using `otThreadGetNextNeighborInfo()`, and retrieving the member `mLastCs` of the `otRouterInfo` structure.

NOTE: Both of the above APIs have been tested (with the mesh extender), and they work.