### PR TITLE
Allow enabling/disabling of packet dump logs

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -383,6 +383,13 @@ if(OT_FULL_LOGS)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_LOG_PREPEND_LEVEL=1")
 endif()
 
+option(OT_PACKET_DUMP_LOGS "enable packet dump logs" ON)
+if(OT_PACKET_DUMP_LOGS)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_LOG_PKT_DUMP=1")
+else()
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_LOG_PKT_DUMP=0")
+endif()
+
 option(OT_OTNS "enable OTNS support")
 if(OT_OTNS)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_OTNS_ENABLE=1")


### PR DESCRIPTION
There is now a cmake option to enable/disable packet dump logs. The reason for adding this, is to alleviate the serial COMS when using DEBG logs. In my specific case, enabling DEBG logs was causing too much delay for normal device operation within the network topology that I was testing. But by disabling packet dumps, I am now able to use DEBG logs.

This option is ON by default, so this won't affect logs for anyone, unless explicitly set to OFF.

Here is what the logs look like with this setting Packet Dumps ON:

```
Rx: 4294855388ms DEBG: MAC Rx Data Indication


Rx: -111903ms: [I] MeshForwarder-: Received IPv6 UDP msg, len:84, chksum:1093, from:16a90fe00dee83de, sec:no, prio:net, rss:-71.0

Rx: -111887ms: [I] MeshForwarder-:     src:[fe80:0:0:0:14a9:fe0:dee:83de]:19788

Rx: -111865ms: [I] MeshForwarder-:     dst:[ff02:0:0:0:0:0:0:2]:19788

Rx: -111845ms: [D] Mle-----------: Receive UDP message

Rx: -111824ms: [I] Mle-----------: Receive Parent Request (fe80:0:0:0:14a9:fe0:dee:83de)

Rx: -111805ms: [I] Mle-----------: Delay Parent Response (fe80:0:0:0:14a9:fe0:dee:83de)

Rx: -111455ms: [D] Mle-----------: network id timeout = 15

Rx: -110909ms: [I] Mle-----------: Send delayed message (fe80:0:0:0:14a9:fe0:dee:83de)

Rx: -110900ms: [D] Mac-----------: Request to start operation "TransmitDataDirect"

Rx: -110879ms: [D] Mac-----------: Mac::HandleBeginDirect

Rx: -110860ms: [D] Mac-----------: Allocated MSDU Handle 9c

Rx: -110844ms: [D] Mac-----------: calling otPlatRadioTransmit for direct

Rx: -110826ms: [D] Mac-----------: Sam 3; Dam 3; MH 9c; DstAddr 16a90fe00dee83de;

Rx: -110804ms: [D] Mac-----------: =============================[Msdu len=090]=============================

Rx: -110781ms: [D] Mac-----------: | 7F 33 F0 4D 4C 4D 4C 33 | CF 00 15 C0 1B 00 00 00 | .3pMLML3O..@....

Rx: -110760ms: [D] Mac-----------: | 00 00 00 01 09 8E C6 02 | 7A 74 F3 96 8E AF D7 80 | ......F.zts../W.

Rx: -110739ms: [D] Mac-----------: | 03 7B 2F AD 58 76 E8 4D | 71 71 7C E1 25 25 DA 40 | .{/-XvhMqq|a%%Z@

Rx: -110718ms: [D] Mac-----------: | 5C 90 94 46 E9 E1 40 70 | EB EE EC 5B E7 08 EE B4 | \..Fia@pknl[g.n4

Rx: -110697ms: [D] Mac-----------: | D4 F8 3F 93 10 31 66 DF | 68 CC 77 8B 67 8D 8E 75 | Tx?..1f_hLw.g..u

Rx: -110676ms: [D] Mac-----------: | 69 59 34 28 8F 3E DB 66 | 52 0F .. .. .. .. .. .. | iY4(.>[fR.......

Rx: -110655ms: [D] Mac-----------: ------------------------------------------------------------------------

Rx: -110601ms: [D] Mac-----------: Starting operation "TransmitDataDirect"

Rx: -110594ms: [D] Mac-----------: Finishing operation "TransmitDataDirect"

Rx: -110572ms: [D] Mac-----------: TransmitDoneTask Called

Rx: -110553ms: [D] Mac-----------: Transmit Error: NoAck
```

And with them OFF:
```
Rx: -265865ms: [I] MeshForwarder-: Received IPv6 UDP msg, len:84, chksum:f43d, from:2aac2ee564f1e32b, sec:no, prio:net, rss:-46.0

Rx: -265851ms: [I] MeshForwarder-:     src:[fe80:0:0:0:28ac:2ee5:64f1:e32b]:19788

Rx: -265829ms: [I] MeshForwarder-:     dst:[ff02:0:0:0:0:0:0:2]:19788

Rx: -265809ms: [D] Mle-----------: Receive UDP message

Rx: -265789ms: [I] Mle-----------: Receive Parent Request (fe80:0:0:0:28ac:2ee5:64f1:e32b)

Rx: -265769ms: [I] Mle-----------: Delay Parent Response (fe80:0:0:0:28ac:2ee5:64f1:e32b)

Rx: -265348ms: [I] Mle-----------: Send delayed message (fe80:0:0:0:28ac:2ee5:64f1:e32b)

Rx: -265339ms: [D] Mac-----------: Request to start operation "TransmitDataDirect"

Rx: -265319ms: [D] Mac-----------: Mac::HandleBeginDirect

Rx: -265300ms: [D] Mac-----------: Allocated MSDU Handle 9

Rx: -265284ms: [D] Mac-----------: calling otPlatRadioTransmit for direct

Rx: -265266ms: [D] Mac-----------: Sam 3; Dam 3; MH 9; DstAddr 2aac2ee564f1e32b;

Rx: -265243ms: [D] Mac-----------: Starting operation "TransmitDataDirect"

Rx: -265224ms: [D] Mac-----------: Finishing operation "TransmitDataDirect"

Rx: -265202ms: [D] Mac-----------: TransmitDoneTask Called
```