### PR TITLE
Fixes both problems observed in Thread Test Harness test case 5.1.8 (DUT as Router)

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3636,7 +3636,9 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     mParentCandidate.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                               DeviceMode::kModeFullNetworkData));
     mParentCandidate.GetLinkInfo().Clear();
-#if !OPENTHREAD_CONFIG_USE_EXTERNAL_MAC
+#if OPENTHREAD_CONFIG_USE_EXTERNAL_MAC
+    mParentCandidate.GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
+#else
     mParentCandidate.GetLinkInfo().AddRss(linkInfo->GetRss());
 #endif
     mParentCandidate.ResetLinkFailures();


### PR DESCRIPTION
Resolves Cascoda/cascoda-sdk-priv#1002

Fixes the following:
- Device sends Parent Request again after receiving the first set of Parent Responses
- Device always selects latest parent candidate, instead of selecting the best parent candidate