### PR TITLE
NoBuffs fix - kErrorFailed error communicated to upper layer, which will free the buffers

### DIFF
--- a/src/core/mac_extern/mac.cpp
+++ b/src/core/mac_extern/mac.cpp
@@ -1458,7 +1458,7 @@ void Mac::TransmitDoneTask(uint8_t aMsduHandle, Error aError)
             {
                 // If the frame could not be prepared and the tx is being
                 // aborted, forward the error back up.
-                Get<MeshForwarder>.HandleSentFrame(mDirectAckRequested, error, mDirectDstAddress);
+                Get<MeshForwarder>().HandleSentFrame(mDirectAckRequested, error, mDirectDstAddress);
             }
             return;
         }

--- a/src/core/mac_extern/mac.cpp
+++ b/src/core/mac_extern/mac.cpp
@@ -1449,7 +1449,7 @@ void Mac::TransmitDoneTask(uint8_t aMsduHandle, Error aError)
 
     if (aMsduHandle == mDirectMsduHandle)
     {
-        if (aError == kErrorChannelAccessFailure || aError == kErrorFailed)
+        if (aError == kErrorChannelAccessFailure)
         {
             // Failed without even hitting the air, retry silently.
             error = otPlatMcpsDataRequest(&GetInstance(), &mDirectDataReq);

--- a/src/core/mac_extern/mac.cpp
+++ b/src/core/mac_extern/mac.cpp
@@ -1454,6 +1454,12 @@ void Mac::TransmitDoneTask(uint8_t aMsduHandle, Error aError)
             // Failed without even hitting the air, retry silently.
             error = otPlatMcpsDataRequest(&GetInstance(), &mDirectDataReq);
             OT_ASSERT(error == kErrorNone);
+            if (error != kErrorNone)
+            {
+                // If the frame could not be prepared and the tx is being
+                // aborted, forward the error back up.
+                Get<MeshForwarder>.HandleSentFrame(mDirectAckRequested, error, mDirectDstAddress);
+            }
             return;
         }
         if (mJoinerEntrustResponseRequested)


### PR DESCRIPTION
Prevents early return upon kErrorFailed. The early return causes the HandleSentFrame() function to be skipped, and this is the function that frees up buffers.

Also added correct handling of situation where otPlatMcpsDataRequest() returns an error (which should be rare, but still possible).